### PR TITLE
dont add all of fabric api as a transitive dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,7 @@ dependencies {
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-    // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    modImplementation fabricApi.module("fabric-command-api-v2", project.fabric_version)
 
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,7 +20,7 @@
   },
   "depends": {
     "fabricloader": ">=0.14.17",
-    "fabric-api": ">=0.37.1",
+    "fabric-command-api-v2": "*",
     "minecraft": ">=1.20.2-rc.1 <1.21"
   },
   "custom": {


### PR DESCRIPTION
was working on a client mod and was distraught to find out that depending on this library adds the entirety of fabric api onto the classpath